### PR TITLE
Require fizzbuzz file from spec

### DIFF
--- a/spec/fizzbuzz_spec.rb
+++ b/spec/fizzbuzz_spec.rb
@@ -1,4 +1,4 @@
-require_relative './spec_helper.rb'
+require_relative '../fizzbuzz.rb'
 
 describe "fizzbuzz" do
   it 'returns "Fizz" when the number is divisible by 3' do


### PR DESCRIPTION
This PR addresses an issue I found when completing [the RSpec Fizzbuzz module](https://learn.co/tracks/intro-to-ruby-development/ruby-basics/logic-and-conditions/rspec-fizzbuzz), it appears that `fizzbuzz_spec.rb` was requiring `spec_helper.rb` rather than `fizzbuzz.rb`. 

Let me know if I need to do anything further to get this to a spot where it's merge-able.
